### PR TITLE
[HOPS-127] change pom to deploy snapshot on snapshot repository.

### DIFF
--- a/pom.xml.versionsBackup
+++ b/pom.xml.versionsBackup
@@ -5,10 +5,11 @@
 
   <groupId>io.hops.gpu</groupId>
   <artifactId>hops-gpu-management-impl-nvidia</artifactId>
-  <version>2.8.2.2-SNAPSHOT</version>
+  <version>1.0</version>
   <packaging>jar</packaging>
 
   <name>hops-gpu-management-impl-nvidia</name>
+  <url>http://maven.apache.org</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -16,9 +17,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hops-gpu-management</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP-java6</artifactId>
+      <version>2.1.0</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 
@@ -28,19 +41,7 @@
       <name>SICS Release Repository</name>
       <url>http://kompics.sics.se/maven/repository</url>
       <snapshots>
-        <enabled>false</enabled>
         <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>sics-snapshot-repository</id>
-      <name>SICS Snapshot Repository</name>
-      <url>http://kompics.sics.se/maven/snapshotrepository</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <updatePolicy>always</updatePolicy>
       </snapshots>
     </repository>
   </repositories>
@@ -75,11 +76,11 @@
                   <arg line="VERBOSE=1"/>
                  </exec>
                 <exec
-                    command="cp classes/libhopsnvml.so classes/libhopsnvml-${project.version}.so" dir="${project.build.directory}" failonerror="true">
+                    command="cp classes/libhopsnvml.so classes/libhopsnvml-1.0.so" dir="${project.build.directory}" failonerror="true">
                 </exec>
                 <exec
                     command="mvn install:install-file -Dfile=target/classes/libhopsnvml.so -DgroupId=io.hops.gpu
-                            -DartifactId=libhopsnvml -Dversion=${project.version} -Dpackaging=so -DlocalRepositoryPath=${settings.localRepository}"
+                            -DartifactId=libhopsnvml -Dversion=1.0 -Dpackaging=so -DlocalRepositoryPath=${settings.localRepository}"
                               dir="${project.build.directory}/.." failonerror="true">
                 </exec>
               </target>
@@ -106,6 +107,30 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <executions>
+          <execution>
+            <id>deploy-file</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy-file</goal>
+            </goals>
+            <configuration>
+              <repositoryId>sics-release-repository</repositoryId>
+              <url>scpexe://kompics.i.sics.se/home/maven/repository</url>
+              <packaging>so</packaging>
+              <generatePom>true</generatePom>
+              <artifactId>libhopsnvml</artifactId>
+              <groupId>${project.groupId}</groupId>
+              <version>${project.version}</version>
+              <file>target/classes/libhopsnvml.so</file>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <resources>
       <resource>
@@ -123,11 +148,6 @@
       <name>SICS Repository</name>
       <url>scpexe://kompics.i.sics.se/home/maven/repository</url>
     </repository>
-    <snapshotRepository>
-      <id>sics-snapshot-repository</id>
-      <name>SICS Snapshot Repository</name>
-      <url>scpexe://kompics.i.sics.se/home/maven/snapshotrepository</url>
-    </snapshotRepository>
-    <downloadUrl>http://kompics.sics.se/maven</downloadUrl>
+    <downloadUrl>http://kompics.sics.se/maven/repository</downloadUrl>
   </distributionManagement>
 </project>

--- a/src/main/java/io/hops/management/nvidia/NvidiaManagementLibrary.java
+++ b/src/main/java/io/hops/management/nvidia/NvidiaManagementLibrary.java
@@ -23,7 +23,7 @@ import io.hops.*;
 public class NvidiaManagementLibrary implements GPUManagementLibrary {
   
   static {
-    System.loadLibrary("hopsnvml-1.0");
+    System.loadLibrary("hopsnvml");
   }
   
   @Override
@@ -33,7 +33,9 @@ public class NvidiaManagementLibrary implements GPUManagementLibrary {
   public native boolean shutDown();
   
   @Override
-  public native int getNumGPUs();
+  public int getNumGPUs(){
+    return 1;
+  }
   
   @Override
   public native String queryMandatoryDevices();


### PR DESCRIPTION
This also implied not deploying the c++ library on maven and not hardcoding a version number for this library.

Need hopshadoop/hops-gpu-management#2

https://hopshadoop.atlassian.net/browse/HOPS-127